### PR TITLE
Allow bot to get a list of the users

### DIFF
--- a/jbot/src/main/java/me/ramswaroop/jbot/core/slack/SlackService.java
+++ b/jbot/src/main/java/me/ramswaroop/jbot/core/slack/SlackService.java
@@ -1,12 +1,13 @@
 package me.ramswaroop.jbot.core.slack;
 
-import java.util.ArrayList;
-import java.util.List;
 import me.ramswaroop.jbot.core.slack.models.RTM;
 import me.ramswaroop.jbot.core.slack.models.User;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Scope;
 import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * @author ramswaroop

--- a/jbot/src/main/java/me/ramswaroop/jbot/core/slack/SlackService.java
+++ b/jbot/src/main/java/me/ramswaroop/jbot/core/slack/SlackService.java
@@ -1,13 +1,12 @@
 package me.ramswaroop.jbot.core.slack;
 
+import java.util.ArrayList;
+import java.util.List;
 import me.ramswaroop.jbot.core.slack.models.RTM;
 import me.ramswaroop.jbot.core.slack.models.User;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Scope;
 import org.springframework.stereotype.Service;
-
-import java.util.ArrayList;
-import java.util.List;
 
 /**
  * @author ramswaroop
@@ -22,6 +21,7 @@ public class SlackService {
     private User currentUser;
     private List<String> dmChannels;
     private String webSocketUrl;
+    private List<User> users;
 
     /**
      * Start a RTM connection. Fetch the web socket url to connect to, current user details
@@ -34,6 +34,7 @@ public class SlackService {
         currentUser = rtm.getUser();
         dmChannels = rtm.getDmChannels();
         webSocketUrl = rtm.getWebSocketUrl();
+        users = rtm.getUsers();
     }
 
     /**
@@ -73,4 +74,16 @@ public class SlackService {
     public void setWebSocketUrl(String webSocketUrl) {
         this.webSocketUrl = webSocketUrl;
     }
+
+    /**
+     * @return list of users that are known
+     */
+    public List<User> getUsers() {
+        return users;
+    }
+
+    public void setUsers(List<User> users) {
+        this.users = users;
+    }
+    
 }


### PR DESCRIPTION
Get a list of users and return it via SlackService

This was enabled as a fix to #26, but not passed through to the bot.