### PR TITLE
Missing timestamp field has been added to Item as ts.

### DIFF
--- a/jbot/src/main/java/me/ramswaroop/jbot/core/slack/models/Item.java
+++ b/jbot/src/main/java/me/ramswaroop/jbot/core/slack/models/Item.java
@@ -12,6 +12,7 @@ public class Item {
     private String channel;
     private Message message;
     private long created;
+    private String ts;
 
     public String getType() {
         return type;
@@ -43,5 +44,13 @@ public class Item {
 
     public void setCreated(long created) {
         this.created = created;
+    }
+
+    public String getTs() {
+        return this.ts;
+    }
+
+    public void setTs(String ts) {
+        this.ts = ts;
     }
 }


### PR DESCRIPTION
https://api.slack.com/events/reaction_added
Add the 'Message' section it is written that there is a field called ts and it is a String.