### PR TITLE
Set message type in reply method only when it is not explicitly set by the user and add support for markdown in attachment model

### DIFF
--- a/jbot/src/main/java/me/ramswaroop/jbot/core/slack/Bot.java
+++ b/jbot/src/main/java/me/ramswaroop/jbot/core/slack/Bot.java
@@ -1,8 +1,7 @@
 package me.ramswaroop.jbot.core.slack;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import me.ramswaroop.jbot.core.slack.models.Event;
-import me.ramswaroop.jbot.core.slack.models.Message;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -14,12 +13,22 @@ import org.springframework.web.socket.WebSocketSession;
 import org.springframework.web.socket.client.WebSocketConnectionManager;
 import org.springframework.web.socket.client.standard.StandardWebSocketClient;
 
-import javax.annotation.PostConstruct;
 import java.io.IOException;
 import java.lang.reflect.Method;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Queue;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+
+import javax.annotation.PostConstruct;
+
+import me.ramswaroop.jbot.core.slack.models.Event;
+import me.ramswaroop.jbot.core.slack.models.Message;
 
 /**
  * Base class for making Slack Bots. Any class extending
@@ -234,7 +243,9 @@ public abstract class Bot {
      */
     public final void reply(WebSocketSession session, Event event, Message reply) {
         try {
-            reply.setType(EventType.MESSAGE.name().toLowerCase());
+            if (StringUtils.isEmpty(reply.getType())) {
+                reply.setType(EventType.MESSAGE.name().toLowerCase());
+            }
             reply.setText(encode(reply.getText()));
             if (reply.getChannel() == null && event.getChannelId() != null) {
                 reply.setChannel(event.getChannelId());

--- a/jbot/src/main/java/me/ramswaroop/jbot/core/slack/models/Attachment.java
+++ b/jbot/src/main/java/me/ramswaroop/jbot/core/slack/models/Attachment.java
@@ -1,12 +1,16 @@
 package me.ramswaroop.jbot.core.slack.models;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
 
 /**
  * Created by ramswaroop on 12/06/2016.
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class Attachment {
     private String fallback;
     private String color;
@@ -30,6 +34,9 @@ public class Attachment {
     @JsonProperty("footer_icon")
     private String footerIcon;
     private String ts;
+
+    @JsonProperty("mrkdwn_in")
+    private List<String> markdownIn;
 
     public String getFallback() {
         return fallback;
@@ -149,6 +156,14 @@ public class Attachment {
 
     public void setTs(String ts) {
         this.ts = ts;
+    }
+
+    public List<String> getMarkdownIn() {
+        return markdownIn;
+    }
+
+    public void setMarkdownIn(List<String> markdownIn) {
+        this.markdownIn = markdownIn;
     }
 }
 

--- a/jbot/src/main/java/me/ramswaroop/jbot/core/slack/models/Attachment.java
+++ b/jbot/src/main/java/me/ramswaroop/jbot/core/slack/models/Attachment.java
@@ -1,7 +1,6 @@
 package me.ramswaroop.jbot.core.slack.models;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.util.List;
@@ -10,7 +9,6 @@ import java.util.List;
  * Created by ramswaroop on 12/06/2016.
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
-@JsonInclude(JsonInclude.Include.NON_NULL)
 public class Attachment {
     private String fallback;
     private String color;


### PR DESCRIPTION
This is for open issue #48 
1. Set message type in reply method only when it is not explicitly set by the user
2. Optimized imports

This is for issue #51 
1. Added attribute for markdown support in attachments


