### PR TITLE
Adds ChannelID to DmChannel List on EventType `im_created`.

### DIFF
--- a/jbot/src/main/java/me/ramswaroop/jbot/core/slack/Bot.java
+++ b/jbot/src/main/java/me/ramswaroop/jbot/core/slack/Bot.java
@@ -169,6 +169,8 @@ public abstract class Bot {
             if (event.getType() != null) {
                 if (event.getType().equalsIgnoreCase(EventType.IM_OPEN.name())) {
                     slackService.addDmChannel(event.getChannelId());
+                } else if (event.getType().equalsIgnoreCase(EventType.IM_CREATED.name())) {
+                    slackService.addDmChannel(event.getChannel().getId());
                 } else if (event.getType().equalsIgnoreCase(EventType.MESSAGE.name())) {
                     if (event.getText() != null && event.getText().contains(slackService.getCurrentUser().getId())) { // direct mention
                         event.setType(EventType.DIRECT_MENTION.name());


### PR DESCRIPTION
Allows jbot to tag as Direct Messages, messages that come from a recently opened Direct Message chat.

Specifically, fixes #35 