### PR TITLE
Allow web socket client to be overridden

### DIFF
--- a/jbot/src/main/java/me/ramswaroop/jbot/core/slack/Bot.java
+++ b/jbot/src/main/java/me/ramswaroop/jbot/core/slack/Bot.java
@@ -270,7 +270,7 @@ public abstract class Bot extends BaseBot {
         return message == null ? null : message.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;");
     }
 
-    private StandardWebSocketClient client() {
+    protected StandardWebSocketClient client() {
         return new StandardWebSocketClient();
     }
 


### PR DESCRIPTION
I'd like to be able to provide a different StandardWebSocketClient, to allow control of error behaviours and transparently re-connect the connection to slack - to do that I'd need to make client protected, so I can override in my sub-class.